### PR TITLE
Update link to zmq doc

### DIFF
--- a/code/e09_zmq_listen.py
+++ b/code/e09_zmq_listen.py
@@ -11,7 +11,7 @@ socket = context.socket(zmq.SUB)
 
 # Subscribe to new transaction and confirmed transaction events
 # For a list of available topics to sbuscribe to see the documentation
-# https://docs.iota.org/docs/iri/0.1/references/zmq-events
+# https://docs.iota.org/docs/node-software/0.1/iri/references/zmq-events
 
 socket.setsockopt(zmq.SUBSCRIBE, b'tx') # Subscribe to all new transactions, including trytes
 socket.setsockopt(zmq.SUBSCRIBE, b'sn') # Subscribe to all confirmed transactions


### PR DESCRIPTION
The previous link gave me a 404, I believe the page has been moved to this new location.